### PR TITLE
Enable RDP

### DIFF
--- a/Windows-Samples/Tools & Utilities/Enable Remote Desktop/Enable RDP.bat
+++ b/Windows-Samples/Tools & Utilities/Enable Remote Desktop/Enable RDP.bat
@@ -1,0 +1,13 @@
+
+
+REM Open the firewall to allow incoming connections
+netsh advfirewall firewall set rule group="Remote Desktop" new enable=Yes
+
+REM Disable "Deny TS Connections" registry key
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f
+
+REM Set service to start automatically at boot 
+sc config termservice start= auto
+
+REM Start service
+net start termservice

--- a/Windows-Samples/Tools & Utilities/Enable Remote Desktop/Enable RDP.bat
+++ b/Windows-Samples/Tools & Utilities/Enable Remote Desktop/Enable RDP.bat
@@ -1,4 +1,10 @@
-
+<# Enables RDP on target machine
+  .SYNOPSIS
+    1. Opens firewall to allow incoming connections
+    2. Disables "Deny TS Connections" registry key
+    3. Sets termservice to start automatically at boot 
+    4. Starts termservice
+#>
 
 REM Open the firewall to allow incoming connections
 netsh advfirewall firewall set rule group="Remote Desktop" new enable=Yes

--- a/Windows-Samples/Tools & Utilities/Enable Remote Desktop/README.md
+++ b/Windows-Samples/Tools & Utilities/Enable Remote Desktop/README.md
@@ -1,0 +1,15 @@
+Overview
+Author: ulv1
+Date Uploaded: 18/01/2018
+Tested on
+AirWatch 9.2.3.0: Completed 
+Client Operating System: Windows 10 (1709)
+
+Description
+Enables RDP on target machine.
+
+What does the sample do?
+1. Opens firewall to allow incoming connections
+2. Disables "Deny TS Connections" registry key
+3. Sets termservice to start automatically at boot 
+4. Starts termservice


### PR DESCRIPTION
Sample to Enable RDP on target machine, works on Windows machines from 7-10 and tested on latest builds of AirWatch and Windows 10.

(First time making a pull request, hopefully, followed routine as established in https://github.com/ulv1/AirWatch-samples/tree/master/Windows-Samples) 